### PR TITLE
chore: python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
 FROM cgr.dev/chainguard/wolfi-base AS builder
-ARG TARGETARCH
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 ARG SALT_VERSION=3007.0
 USER root
 RUN apk add --no-cache python-${PYTHON_VERSION} cython libcrypto3 libgit2-dev libgit2 python-${PYTHON_VERSION}-dev gcc build-base glibc-dev ld-linux
 RUN python -m venv /venv
 RUN /venv/bin/pip install -U pip
-RUN /venv/bin/pip install salt==${SALT_VERSION} pygit2 croniter tornado backports.ssl-match-hostname pycrypto
+RUN /venv/bin/pip install salt==${SALT_VERSION} pygit2 croniter tornado pycrypto
 RUN /venv/bin/pip uninstall -y setuptools pip
 
 FROM cgr.dev/chainguard/wolfi-base AS runner
 ARG TARGETARCH
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 LABEL org.opencontainers.image.title "Saltstack container"
 LABEL org.opencontainers.image.description "Saltstack with minimal dependencies"
 LABEL org.opencontainers.image.authors "githubcdr"


### PR DESCRIPTION
- python 3.12
- drop legacy module
